### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,8 @@
 fixtures:
   repositories:
     common: "git://github.com/simp/pupmod-simp-common"
-    concat: "git://github.com/simp/pupmod-simp-concat"
+    simplib: "git://github.com/simp/pupmod-simp-simplib"
+    simpcat: "git://github.com/simp/pupmod-simp-concat"
     stdlib: "git://github.com/simp/puppetlabs-stdlib"
   symlinks:
     network: "#{source_dir}"

--- a/.fixtures.yml.local
+++ b/.fixtures.yml.local
@@ -3,5 +3,6 @@ fixtures:
   symlinks:
     network: "#{source_dir}"
     common: "#{source_dir}/../common"
-    concat: "#{source_dir}/../concat"
+    simplib: "#{source_dir}/../simplib"
+    simpcat: "#{source_dir}/../simpcat"
     stdlib: "#{source_dir}/../stdlib"

--- a/build/pupmod-network.spec
+++ b/build/pupmod-network.spec
@@ -1,13 +1,14 @@
 Summary: Host Network Puppet Module
 Name: pupmod-network
 Version: 4.1.0
-Release: 4
+Release: 5
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: pupmod-common >= 4.1.0-4
-Requires: pupmod-concat >= 3.4
+Requires: pupmod-simplib >= 1.0.0-0
+Requires: pupmod-simpcat >= 3.4
 Requires: puppet >= 3.3.0
 Buildarch: noarch
 Requires: simp-bootstrap >= 4.2.0
@@ -55,6 +56,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-5
+- migration to simplib and simpcat (lib/ only)
+
 * Fri Mar 06 2015 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.0-4
 - Fixed bug in network::add_eth that trashed bonded nics.
 


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-network`.
SIMP-604 #comment Updated `pupmod-simp-network`.