### PR TITLE
(SIMP-398) Eliminate all uses of lsb* facts

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,4 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,90 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
-rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+before_script:
+  - bundle
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
+  - bundle exec rake test
+notifications:
+  email: false
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,52 @@
-# Environment variables:
+# Variables:
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
+group :test do
+  gem "rake"
+  gem 'puppet', puppetversion
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
 
-gem 'puppet', puppetversion
-gem 'puppet-lint'
-gem 'puppetlabs_spec_helper'
-gem 'puppet_module_spec_helper'
-gem 'simp-rake-helpers'
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
-group :debug do
-    gem 'pry'
-    gem 'pry-doc'
-    gem 'rspec'
-    gem 'mocha'
-    gem 'metadata-json-lint'
+  # simp-rake-helpers does not suport puppet 2.7.X
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
+      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+      # TODO: fix upstream deps (parallel in simp-rake-helpers)
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
+    gem 'simp-rake-helpers'
+  end
+end
+
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+  gem 'pry'
+  gem 'pry-doc'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,28 +1,68 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
+# These gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
 
-require 'simp/rake/pkg'
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
+Rake::Task[:lint].clear
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
+end
 
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
-# Lint Material
 begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
-  PuppetLint.configuration.send("disable_selector_inside_resource")
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
 rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+  # Ignoring this for now since all of these are currently convenience methods.
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/build/pupmod-network.spec
+++ b/build/pupmod-network.spec
@@ -6,7 +6,6 @@ License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-Requires: pupmod-common >= 4.1.0-4
 Requires: pupmod-simplib >= 1.0.0-0
 Requires: pupmod-simpcat >= 3.4
 Requires: puppet >= 3.3.0

--- a/manifests/add_eth.pp
+++ b/manifests/add_eth.pp
@@ -203,27 +203,27 @@ define network::add_eth (
 
 
   if $ensure == 'absent' {
-    file { "/etc/sysconfig/network-scripts/ifcfg-$name":
+    file { "/etc/sysconfig/network-scripts/ifcfg-${name}":
       ensure => 'absent'
     }
 
-    exec { "/sbin/ifdown $name":
+    exec { "/sbin/ifdown ${name}":
       onlyif => "/sbin/ip link show up | /usr/bin/tr -d ' ' | /bin/grep '^[[:digit:]]' | /bin/cut -f2 -d':' | /bin/grep -q '^${name}$'",
-      notify => File["/etc/sysconfig/network-scripts/ifcfg-$name"]
+      notify => File["/etc/sysconfig/network-scripts/ifcfg-${name}"]
     }
   }
   else {
-    file { "/etc/sysconfig/network-scripts/ifcfg-$name":
+    file { "/etc/sysconfig/network-scripts/ifcfg-${name}":
       ensure  => 'file',
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
       content => template('network/eth.erb'),
-      notify  => Exec["network_restart_$name"]
+      notify  => Exec["network_restart_${name}"]
     }
 
     if $net_type == 'Bridge' or $bridge != '' or $bonding or $slave != '' {
-      exec { "network_restart_$name":
+      exec { "network_restart_${name}":
         command     => '/bin/true',
         refreshonly => true,
         notify      => Service['network']
@@ -267,7 +267,7 @@ define network::add_eth (
       # it's coming up. If it took more than 10 seconds, something's probably
       # very wrong with your network.
       $command_string = $auto_restart ? {
-        true    => "/sbin/ifdown $name ; /sbin/ifup $name && wait && sleep 10",
+        true    => "/sbin/ifdown ${name} ; /sbin/ifup ${name} && wait && sleep 10",
         default => '/bin/true',
       }
 
@@ -276,7 +276,7 @@ define network::add_eth (
         default             => '/bin/false'
       }
 
-      exec { "network_restart_$name":
+      exec { "network_restart_${name}":
         command     => $command_string,
         refreshonly => $refreshonly,
         onlyif      => $onlyif
@@ -290,13 +290,13 @@ define network::add_eth (
         group   => 'root',
         mode    => '0640',
         content => template('network/modprobe_bond.erb'),
-        notify  => Exec["activate_bonding_$name"]
+        notify  => Exec["activate_bonding_${name}"]
       }
 
-      exec { "activate_bonding_$name":
-        command     => "/sbin/modprobe -r $name && /sbin/modprobe $name",
+      exec { "activate_bonding_${name}":
+        command     => "/sbin/modprobe -r ${name} && /sbin/modprobe ${name}",
         refreshonly => true,
-        notify      => Exec["network_restart_$name"]
+        notify      => Exec["network_restart_${name}"]
       }
     }
   }

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -50,6 +50,7 @@ class network::global (
   $auto_restart = true,
   $persistent_dhclient = ''
 ) {
+  validate_bool($auto_restart)
 
   file { '/etc/sysconfig/network':
     owner   => 'root',
@@ -59,13 +60,13 @@ class network::global (
     notify  => Exec['global_network_restart']
   }
 
-  exec { 'global_network_restart':
-    command     => $auto_restart ? {
-      true    => '/sbin/service network restart',
-      default => '/bin/true'
-    },
-    refreshonly => true
+  $_command = $auto_restart ? {
+    true    => '/sbin/service network restart',
+    default => '/bin/true'
   }
 
-  validate_bool($auto_restart)
+  exec { 'global_network_restart':
+    command     => $_command,
+    refreshonly => true
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,16 +22,18 @@ class network (
     require   => File['/usr/local/sbin/careful_network_restart.sh']
   }
 
+  $_content = $auto_restart ? {
+    true    => '#!/bin/sh
+while [ `/bin/ps h -fC puppet,puppetd | /bin/grep -ce "puppet\(d\| agent\)"` -gt 0 ]; do /bin/sleep 5; done; /sbin/service network restart
+',
+    default => '/bin/true'
+  }
+
   file { '/usr/local/sbin/careful_network_restart.sh':
     ensure  => 'file',
     mode    => '0750',
     owner   => 'root',
     group   => 'root',
-    content => $auto_restart ? {
-      true    => '#!/bin/sh
-while [ `/bin/ps h -fC puppet,puppetd | /bin/grep -ce "puppet\(d\| agent\)"` -gt 0 ]; do /bin/sleep 5; done; /sbin/service network restart
-',
-      default => '/bin/true'
-    }
+    content => $_content
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,37 @@
+{
+  "name":    "simp-network",
+  "version": "4.1.0",
+  "author":  "simp",
+  "summary": "manages host networking",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-network",
+  "project_page": "https://github.com/simp/pupmod-simp-network",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "network", "interface" ],
+  "dependencies": [
+    {
+      "name": "simp-simpcat",
+      "version_requirement": ">= 3.4.0"
+    },
+    {
+      "name": "simp-simplib",
+      "version_requirement": ">= 1.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/classes/global_spec.rb
+++ b/spec/classes/global_spec.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe 'network::global' do
   # Look in hieradata/default.yaml for variables that were set for this test.
 
-  it { should create_class('network::global') }
-  it { should create_file('/etc/sysconfig/network').with_content(/GATEWAY=1\.2\.3\.4/) }
+  it { is_expected.to create_class('network::global') }
+  it { is_expected.to create_file('/etc/sysconfig/network').with_content(/GATEWAY=1\.2\.3\.4/) }
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'network' do
 
-  it { should create_class('network') }
-  it { should contain_service('network').with_ensure('running') }
-  it { should create_file('/usr/local/sbin/careful_network_restart.sh') }
+  it { is_expected.to create_class('network') }
+  it { is_expected.to contain_service('network').with_ensure('running') }
+  it { is_expected.to create_file('/usr/local/sbin/careful_network_restart.sh') }
 end

--- a/spec/defines/add_eth_spec.rb
+++ b/spec/defines/add_eth_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'network::add_eth' do
   let(:facts) {{
-    :lsbmajdistrelease => '6'
+    :operatingsystemmajrelease => '6'
   }}
 
   context 'base' do
@@ -15,9 +15,9 @@ describe 'network::add_eth' do
       :hwaddr    => 'CA:FE:BA:BE:00:FF'
     }}
 
-    it { should create_file('/etc/sysconfig/network-scripts/ifcfg-test_eth').with_content(/^BOOTPROTO=dhcp/) }
-    it { should create_file('/etc/sysconfig/network-scripts/ifcfg-test_eth').with_content(/^HWADDR=CA:FE:BA:BE:00:FF/) }
-    it { should create_file('/etc/sysconfig/network-scripts/ifcfg-test_eth').without_content(/^(?!\w|#|\s*$)/) }
+    it { is_expected.to create_file('/etc/sysconfig/network-scripts/ifcfg-test_eth').with_content(/^BOOTPROTO=dhcp/) }
+    it { is_expected.to create_file('/etc/sysconfig/network-scripts/ifcfg-test_eth').with_content(/^HWADDR=CA:FE:BA:BE:00:FF/) }
+    it { is_expected.to create_file('/etc/sysconfig/network-scripts/ifcfg-test_eth').without_content(/^(?!\w|#|\s*$)/) }
   end
 
   context 'bond' do
@@ -32,7 +32,7 @@ describe 'network::add_eth' do
       :userctl     => 'no',
     }}
 
-    it { should create_file('/etc/sysconfig/network-scripts/ifcfg-test_bond').with_content(/^BONDING_OPTS='miimon=100 mode=4'/) }
-    it { should create_file('/etc/sysconfig/network-scripts/ifcfg-test_bond').without_content(/^(?!\w|#|\s*$)/) }
+    it { is_expected.to create_file('/etc/sysconfig/network-scripts/ifcfg-test_bond').with_content(/^BONDING_OPTS='miimon=100 mode=4'/) }
+    it { is_expected.to create_file('/etc/sysconfig/network-scripts/ifcfg-test_bond').without_content(/^(?!\w|#|\s*$)/) }
   end
 end

--- a/spec/defines/route_spec.rb
+++ b/spec/defines/route_spec.rb
@@ -9,5 +9,5 @@ describe 'network::route' do
     :next_hop     => '1.2.3.5'
   }}
 
-  it { should create_file('/etc/sysconfig/network-scripts/route-test_eth') }
+  it { is_expected.to create_file('/etc/sysconfig/network-scripts/route-test_eth') }
 end

--- a/templates/eth.erb
+++ b/templates/eth.erb
@@ -163,7 +163,7 @@
   end
 
   if not @dhclient_timeout.empty? then
-    if scope.function_versioncmp([@lsbmajdistrelease,'6']) < 0 then
+    if scope.function_versioncmp([@operatingsystemmajrelease,'6']) < 0 then
       t_dhclientargs << "-T #{@dhclient_timeout}"
     else
       t_dhclientargs << "-timeout #{@dhclient_timeout}"


### PR DESCRIPTION
This commit replaces all `lsb*` facts with their (package-independent)
`operatingsystem*` counterparts.  Common module assets have also been
normalized, and lint errors have been corrected.

SIMP-673 #close
SIMP-398 #comment updated `pupmod-simp-network`
SIMP-667 #comment updated `pupmod-simp-network`
