### PR TITLE
(SIMP-1544) Puppet 4 compatibility fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Sep 26 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.2-0
+- Ensure that no calls to 'function_defined' are present in any templates for
+  Puppet 4 compatibility
+
 * Thu May 19 2016 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.1-0
 - Sanitize code for `STRICT_VARIABLES=yes`
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-network",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "author": "simp",
   "summary": "manages host networking",
   "license": "Apache-2.0",


### PR DESCRIPTION
Needed to remove a floating `scope.function_defined` call inside of an
inline template.

Puppet 3 didn't play well with moving to `has_variable?` so the code
was updated to fetch the instance variable for the interface directly.

SIMP-1544 #close