### PR TITLE
(SIMP-1450) Updated to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Updated to use the new 'simpcat' that deconflicts with 'puppetlabs/concat'
+
 * Mon Sep 26 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.2-0
 - Ensure that no calls to 'function_defined' are present in any templates for
   Puppet 4 compatibility

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,2 +1,2 @@
-Requires: pupmod-simp-simpcat >= 3.4
+Requires: pupmod-simp-simpcat >= 6.0.0
 Obsoletes: pupmod-network-test >= 0.0.1

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -35,19 +35,19 @@ define network::route (
     owner     => 'root',
     group     => 'root',
     mode      => '0644',
-    subscribe => Concat_build["route_${interface}"],
+    subscribe => Simpcat_build["route_${interface}"],
     notify    => Exec["route_restart_${name}"],
     audit     => content
   }
 
-  if !defined(Concat_build["route_${interface}"]) {
-    concat_build { "route_${interface}":
+  if !defined(Simpcat_build["route_${interface}"]) {
+    simpcat_build { "route_${interface}":
       target        => "/etc/sysconfig/network-scripts/route-${interface}",
       squeeze_blank => true
     }
   }
 
-  concat_fragment { "route_${interface}+${name}":
+  simpcat_fragment { "route_${interface}+${name}":
     content => "${cidr_netmask} via ${next_hop}\n",
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-network",
-  "version": "4.1.2",
+  "version": "5.0.0",
   "author": "simp",
   "summary": "manages host networking",
   "license": "Apache-2.0",
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "simp-simpcat",
-      "version_requirement": ">= 3.4.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp-simplib",


### PR DESCRIPTION
Updated the module to use the new 'simpcat' which deconflicts with the
'puppetlabs/concat' module.

SIMP-1450 #comment Updated to use new 'simpcat'
SIMP-843 #comment Deconflicted 'network'
