### PR TITLE
(SIMP-6100) Replace validate_macaddresses with Simplib::Macaddress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.16' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Feb 11 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.4-0
+- Use Simplib::Macaddress data type in lieu of validate_macaddresses(),
+  a deprecated simplib Puppet 3 function.
+
 * Thu Nov 01 2018 Jeanne Greulich <jeanne,greulich@onyxpoint.com> - 6.0.3-0
 - Static asset updates for puppet 5
 - Update badges and contribution guide URL in README.md

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 
 ## This is a SIMP module
-This module is a component of the [System Integrity Management Platform](https://github.com/NationalSecurityAgency/SIMP), a compliance-management framework built on Puppet.
+
+This module is a component of the [System Integrity Management Platform](https://simp-project.com),
+a compliance-management framework built on Puppet.
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 

--- a/manifests/eth.pp
+++ b/manifests/eth.pp
@@ -139,7 +139,7 @@ define network::eth (
   Optional[Boolean]                 $reorder_hdr                      = undef,
   Optional[Simplib::IP]             $gateway                          = undef,
   Optional[Boolean]                 $hotplug                          = undef,
-  Optional[String]                  $hwaddr                           = undef,
+  Optional[Simplib::Macaddress]     $hwaddr                           = undef,
   Optional[Simplib::IP]             $ipaddr                           = undef,
   Optional[Boolean]                 $ipv6_autoconf                    = undef,
   Optional[Boolean]                 $ipv6_control_radvd               = undef,
@@ -158,7 +158,7 @@ define network::eth (
   Optional[Boolean]                 $ipv6to4init                      = undef,
   Optional[Boolean]                 $isalias                          = undef,
   Optional[Integer]                 $linkdelay                        = undef,
-  Optional[String]                  $macaddr                          = undef,
+  Optional[Simplib::Macaddress]     $macaddr                          = undef,
   Optional[String]                  $master                           = undef,
   Optional[String]                  $metric                           = undef,
   Optional[Integer]                 $mtu                              = undef,
@@ -180,9 +180,6 @@ define network::eth (
   String $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
 ) {
   include '::network'
-
-  if $macaddr { validate_macaddress($macaddr) }
-  if $hwaddr  { validate_macaddress($hwaddr) }
 
   if $ensure == 'absent' {
     file { "/etc/sysconfig/network-scripts/ifcfg-${name}":

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-network",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "author": "SIMP Team",
   "summary": "manages host networking",
   "license": "Apache-2.0",
@@ -23,7 +23,7 @@
     },
     {
       "name": "simp-simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.7.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Use Simplib::Macaddress data type in lieu of validate_macaddresses(),
  a deprecated simplib Puppet 3 function.
- Update SIMP URL in README.md

SIMP-6100 #close