### PR TITLE
SIMP-MAINT Update upper bound of concat

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     },
     {
       "name": "simp-simplib",


### PR DESCRIPTION
Update upper bound of concat to accommodate version to
be delivered with SIMP 6.4.0