### PR TITLE
Add support for multiple static routes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jul 08 2022 befischer-noris <108938973+befischer-noris@users.noreply.github.com> - 6.3.1
+- Add support for multiple static routes
+
 * Wed Jun 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.3.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -16,7 +16,7 @@
 ### Defined types
 
 * [`network::eth`](#networketh): This sets up a particular ethernet device config file.  See /usr/share/doc/initscripts-<version>/sysconfig.txt for details of each option.  F
-* [`network::route`](#networkroute): Add a static route to an interface.  See /usr/share/doc/initscripts-<version>/sysconfig.txt for details of each option.  Note: At this time m
+* [`network::route`](#networkroute): Add a static route to an interface.  See `/usr/share/doc/initscripts-*/sysconfig.txt` for details of each option.
 
 ### Data types
 
@@ -980,13 +980,36 @@ Default value: ``undef``
 
 Add a static route to an interface.
 
-See /usr/share/doc/initscripts-<version>/sysconfig.txt for details of
+See `/usr/share/doc/initscripts-*/sysconfig.txt` for details of
 each option.
 
-Note: At this time multiple static routes can only be added by injecting
-      newlines into the cidr_netmask variable. See the following as an example:
+#### Examples
 
-      cidr_netmask => "192.168.1.0/24 via 192.168.0.1\n192.168.2.0/24"
+##### Defining a static route (Hiera)
+
+```puppet
+eth0-1.1.1.1:
+  interface: eth0
+  next_hop: 8.8.8.8
+  cidr_netmask: 1.1.1.1/32
+  auto_restart: true # <- default
+```
+
+##### Defining multiple routes for the same interface (Puppet code)
+
+```puppet
+network::route{ 'eth1-first-static-route':
+  interface    => 'eth1',
+  cidr_netmask => "192.168.1.0/24',
+  next_hop     => '192.168.1.1,
+}
+
+network::route{ 'eth1-second-static-route':
+  interface    => 'eth1',
+  cidr_netmask => '192.168.3.0/24',
+  next_hop     => '192.168.3.1',
+}
+```
 
 #### Parameters
 

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -3,10 +3,12 @@
 # See /usr/share/doc/initscripts-<version>/sysconfig.txt for details of
 # each option.
 #
-# Note: At this time multiple static routes can only be added by injecting
-#       newlines into the cidr_netmask variable. See the following as an example:
-#
-#       cidr_netmask => "192.168.1.0/24 via 192.168.0.1\n192.168.2.0/24"
+# Routes should be defined as the following:
+# eth0-1.1.1.1:
+#   interface: eth0
+#   next-hop: 8.8.8.8
+#   cidr_netmask: 1.1.1.1/32
+#   auto_restart: true # <- default
 #
 # @param interface
 # @param cidr_netmask
@@ -41,7 +43,7 @@ define network::route (
   }
 
   $_command = $auto_restart ? {
-    true    => "/sbin/ifdown ${name} && /sbin/ifup ${name}; wait",
+    true    => "/sbin/ifdown ${interface} && /sbin/ifup ${interface}; wait",
     default => '/bin/true'
   }
 

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -4,11 +4,12 @@
 # each option.
 #
 # Routes should be defined as the following:
-# eth0-1.1.1.1:
-#   interface: eth0
-#   next-hop: 8.8.8.8
-#   cidr_netmask: 1.1.1.1/32
-#   auto_restart: true # <- default
+# @example
+#   eth0-1.1.1.1:
+#     interface: eth0
+#     next_hop: 8.8.8.8
+#     cidr_netmask: 1.1.1.1/32
+#     auto_restart: true # <- default
 #
 # @param interface
 # @param cidr_netmask

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -1,15 +1,28 @@
 # Add a static route to an interface.
 #
-# See /usr/share/doc/initscripts-<version>/sysconfig.txt for details of
+# See `/usr/share/doc/initscripts-*/sysconfig.txt` for details of
 # each option.
 #
-# Routes should be defined as the following:
-# @example
+# @example Defining a static route (Hiera)
 #   eth0-1.1.1.1:
 #     interface: eth0
 #     next_hop: 8.8.8.8
 #     cidr_netmask: 1.1.1.1/32
 #     auto_restart: true # <- default
+#
+# @example Defining multiple routes for the same interface (Puppet code)
+#   network::route{ 'eth1-first-static-route':
+#     interface    => 'eth1',
+#     cidr_netmask => "192.168.1.0/24',
+#     next_hop     => '192.168.1.1,
+#   }
+#
+#   network::route{ 'eth1-second-static-route':
+#     interface    => 'eth1',
+#     cidr_netmask => '192.168.3.0/24',
+#     next_hop     => '192.168.3.1',
+#   }
+#
 #
 # @param interface
 # @param cidr_netmask

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-network",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "author": "SIMP Team",
   "summary": "manages host networking",
   "license": "Apache-2.0",

--- a/spec/defines/route_spec.rb
+++ b/spec/defines/route_spec.rb
@@ -17,6 +17,25 @@ describe 'network::route' do
           it { is_expected.to create_concat_fragment('route_test_eth+test_route').with_content("1.2.3.4/32 via 1.2.3.5\n") }
         end
 
+        context 'with multiple routes for the same interface' do
+          let(:pre_condition) {%Q(
+            network::route{ 'another_route':
+              interface    => 'test_eth',
+              cidr_netmask => '2.3.4.5/32',
+              next_hop     => '2.3.4.6'
+            }
+          )}
+          let(:title) {'test_route'}
+          let(:params) {{
+            :interface    => 'test_eth',
+            :cidr_netmask => '1.2.3.4/32',
+            :next_hop     => '1.2.3.5'
+          }}
+          it { is_expected.to create_concat('route_test_eth') }
+          it { is_expected.to create_concat_fragment('route_test_eth+test_route').with_content("1.2.3.4/32 via 1.2.3.5\n") }
+          it { is_expected.to create_concat_fragment('route_test_eth+another_route').with_content("2.3.4.5/32 via 2.3.4.6\n") }
+        end
+
       end
     end
   end


### PR DESCRIPTION
For this we only have to use the already existing not mandatory interface parameter `${interface}` in the ifup/ifdown command
This allows to define multiple network::routes named like `eth0-10.0.0.0`, `eth0-20.0.0.0` and so on.

This shouldn't affect other users because the specified name by them is not beeing used different.