### PR TITLE
Support more downstream distributions and version 9 too

### DIFF
--- a/manifests/eth.pp
+++ b/manifests/eth.pp
@@ -195,7 +195,7 @@ define network::eth (
   include 'network'
 
   if ($net_type == 'Bridge') or ($bridge =~ NotUndef) {
-    if ($facts['os']['name'] in ['RedHat','CentOS','OracleLinux']) and ($facts['os']['release']['major'] < '8') {
+    if ($facts['os']['name'] in ['RedHat','CentOS','OracleLinux','Rocky','AlmaLinux']) and ($facts['os']['release']['major'] < '8') {
       include 'network::eth::bridge_packages'
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -31,21 +31,40 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "7",
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLimux",
+      "operatingsystemrelease": [
+        "7",
+        "8",
+        "9"
       ]
     }
   ],


### PR DESCRIPTION
At the moment this module does not support Rocky Linux nor Alma Linux. Neither it does support version 9 of any RHEL distribution. This PR aims to add support for those downstream distributions and initiates (basic) support for version 9 too.