### PR TITLE
Add autoconnect_slaves parameter

### DIFF
--- a/manifests/eth.pp
+++ b/manifests/eth.pp
@@ -29,6 +29,7 @@
 #   ignored.
 #
 # @param arp
+# @param autoconnect_slaves
 # @param bond_arp_interval
 # @param bond_arp_ip_target
 # @param bond_downdelay
@@ -121,6 +122,7 @@
 #
 define network::eth (
   Optional[Boolean]                 $arp                              = undef,
+  Optional[Boolean]                 $autoconnect_slaves               = undef,
   Boolean                           $auto_discover_mac                = true,
   Boolean                           $bonding                          = false,
   Optional[Integer]                 $bond_arp_interval                = undef,

--- a/spec/defines/eth_spec.rb
+++ b/spec/defines/eth_spec.rb
@@ -69,6 +69,7 @@ describe 'network::eth' do
           let(:title) { 'everything_eth' }
           let(:params) {{
             :arp                              => true,
+            :autoconnect_slaves               => true,
             :auto_discover_mac                => true,
             :bonding                          => true,
             :bond_arp_interval                => 5,

--- a/spec/expected/everything_eth.el7
+++ b/spec/expected/everything_eth.el7
@@ -50,3 +50,4 @@ LINKDELAY=5
 BRIDGE=br0
 NM_CONTROLLED=no
 BONDING_OPTS='arp_interval=5 arp_ip_target=192.168.1.1 #lacp_rate=1 max_bonds=5 miimon=100 downdelay=2 updelay=3 mode=4 bond_use_carrier=1 xmit_hash_policy=layer2+3'
+AUTOCONNECT_SLAVES=yes

--- a/spec/expected/everything_eth.el8
+++ b/spec/expected/everything_eth.el8
@@ -50,3 +50,4 @@ LINKDELAY=5
 BRIDGE=br0
 NM_CONTROLLED=no
 BONDING_OPTS='arp_interval=5 arp_ip_target=192.168.1.1 #lacp_rate=1 max_bonds=5 miimon=100 downdelay=2 updelay=3 mode=4 bond_use_carrier=1 xmit_hash_policy=layer2+3'
+AUTOCONNECT_SLAVES=yes

--- a/templates/eth.erb
+++ b/templates/eth.erb
@@ -258,5 +258,9 @@
   unless t_bonding_options.empty?
     eth_opts << "BONDING_OPTS='#{t_bonding_options.join(' ')}'"
   end
+
+  unless @autoconnect_slaves.nil?
+    eth_opts << "AUTOCONNECT_SLAVES=#{bool_to_yesno[@autoconnect_slaves]}"
+  end
 -%>
 <%= eth_opts.join("\n") %>


### PR DESCRIPTION
Add autocennect_slaves as configurable parameter.

When running VMs on a KVM host, vnetX tunnels are created for every VMs NIC and attached as slaves to the bridge interface of the host. When the bridge interface is restarted due to config change or what so ever, vnet tunnels are not attached again and the VMs have no network. Configuring autoconnect_slaves on the bridge interface solves this issue.