### PR TITLE
[puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 6.8.0
+- [puppetsync] Add EL9 support
+
 * Thu Nov 30 2023 castrov <10415785+castrov@users.noreply.github.com> - 6.7.0
 - Add new parameter `network::service::network_manager::puppet_agent_installed`
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
-* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 6.8.0
-- [puppetsync] Add EL9 support
+* Wed Feb 07 2024 Mike Riddle <mike@sicura.us> - 6.8.0
+- [puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd
 
 * Thu Nov 30 2023 castrov <10415785+castrov@users.noreply.github.com> - 6.7.0
 - Add new parameter `network::service::network_manager::puppet_agent_installed`

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-network",
-  "version": "6.7.0",
+  "version": "6.8.0",
   "author": "SIMP Team",
   "summary": "manages host networking",
   "license": "Apache-2.0",
@@ -31,33 +31,38 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     }
   ],


### PR DESCRIPTION
The patch enforces a standardized asset baseline using
simp/puppetsync, and may also apply other updates to
ensure conformity.